### PR TITLE
Refresh list on input url (dataApi) change

### DIFF
--- a/property.json
+++ b/property.json
@@ -5,17 +5,17 @@
         "fields": {
             "dataApi": {
                 "name": "URL for list data",
-                "type": "string",
-                "value": "results.json"
+                "type": "url",
+                "value": "https://vivid-inferno-4587.firebaseio.com/results.json"
             },
             "filterApi": {
                 "name": "URL for the filter",
-                "type": "string",
-                "value": "filter.json"
+                "type": "url",
+                "value": "https://vivid-inferno-4587.firebaseio.com/filter.json"
             },
             "paginatedApi": {
                 "name": "URL for pagination",
-                "type": "string",
+                "type": "url",
                 "value": ""
             }
         }

--- a/t-list.html
+++ b/t-list.html
@@ -329,7 +329,8 @@ after the list became visible again. e.g.
                  */
                 dataApi: {
                     type: String,
-                    value: ""
+                    value: "",
+                    observer: "_dataApiChanged"
                 },
 
                 /**
@@ -523,6 +524,8 @@ after the list became visible again. e.g.
             },
 
             _dataApiChanged: function () {
+                var component = this;
+
                 if (this.dataApi != undefined && this.dataApi != "" && this.auto) {
                     this.$.dataCall.url = this.dataApi + (this.dataApi.indexOf('?') > -1 ? '&' : '?') + component._defaultSorting + "+asc";
                     this._isSorted = true;

--- a/t-list.html
+++ b/t-list.html
@@ -488,6 +488,7 @@ after the list became visible again. e.g.
 
 
         attached: function() {            
+            this.attachedHit = true;
             if (this.auto)
                 this.generateList();
         },
@@ -525,6 +526,8 @@ after the list became visible again. e.g.
 
             _dataApiChanged: function () {
                 var component = this;
+
+                if (!this.attachedHit) return;
 
                 if (this.dataApi != undefined && this.dataApi != "" && this.auto) {
                     this.$.dataCall.url = this.dataApi + (this.dataApi.indexOf('?') > -1 ? '&' : '?') + component._defaultSorting + "+asc";


### PR DESCRIPTION
This component is quite heavily used in applications so I am opening this pull request so that everybody is on the same page regarding the changes I am making. So, list doesn't do anything when you change the input url i.e. value of the `dataApi` property. This feature is needed in the elements browser (atom) where the user is allowed to create and input new urls containing different responses.
@cvenkatasuresh @ManojC @sounakpal 
